### PR TITLE
[update] hyperlink for grammarly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ the action you have taken to solve it.
   - There are no spelling mistakes
   - It reads well
   - For english language contributions: Has a good score on
-    [Grammarly](grammarly.com) or [Hemingway
+    [Grammarly](http://www.grammarly.com) or [Hemingway
     App](http://www.hemingwayapp.com/)
 
 ### Does it move this repository closer to my vision for the repository


### PR DESCRIPTION
### Issue

The hyperlink for grammarly was not pointing to the correct website. ❌

### Fix

Updated the hyperlink for grammarly in CONTRIBUTING.md file. 📃